### PR TITLE
Use sentence case for section headings

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -49,7 +49,7 @@
 
     <section class="section page-shell" id="specimen" aria-labelledby="specimen-title">
       <div class="section-head">
-        <h2 id="specimen-title">Live Specimen</h2>
+        <h2 id="specimen-title">Live specimen</h2>
         <p>
           Edit the sample, adjust the texture, and check punctuation,
           numerals, operators, and brackets at working sizes.
@@ -116,7 +116,7 @@ for (const [index, mark] of marks.entries()) {
 
     <section class="section page-shell" id="code" aria-labelledby="code-title">
       <div class="section-head">
-        <h2 id="code-title">Code Specimen</h2>
+        <h2 id="code-title">Code specimen</h2>
         <p>
           Snippets use compact columns, operators, comments, brackets, string
           marks, and digits that are easy to compare across languages.
@@ -237,7 +237,7 @@ printf '%-18s %8s\n' "release" "$release"</code></pre>
 
     <section class="section page-shell" id="glyphs" aria-labelledby="glyphs-title">
       <div class="section-head">
-        <h2 id="glyphs-title">Glyph Texture</h2>
+        <h2 id="glyphs-title">Glyph texture</h2>
         <p>
           Inspect letterforms, numerals, ambiguous forms, operators, and
           punctuation in a compact bordered grid.


### PR DESCRIPTION
Because they are not titles.