### PR TITLE
Refine Iosevka glyphs and add reusable patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Anthrosevka Mono 0.2.0
+
+### Glyph design
+
+- Adjusted the uppercase `J` serifless hook with a higher, more balanced tail
+  inspired by Anthropic Mono while preserving full glyph height.
+- Refined the uppercase `Q` straight tail so its terminal extends farther right,
+  closer to the right stem.
+- Changed dotted zero from a circular dot to a rectangular dot, matching the
+  Anthropic Mono style dotted zero.
+
+### Maintenance
+
+- Added reusable patch files for the `J`, `Q`, and dotted zero glyph changes.
+- Added `patches/apply-patches.sh` to reapply the glyph patches after
+  refreshing the upstream Iosevka source tree.
+
 ## Anthrosevka Mono 0.1.0
 
 First release of Anthrosevka Mono, an Iosevka custom build inspired by the

--- a/README.md
+++ b/README.md
@@ -25,11 +25,23 @@ The idea is to ship sensible, opinionated defaults for a better experience out o
 Follow [building Iosevka from source](https://github.com/be5invis/Iosevka/blob/main/doc/custom-build.md)
 to set up the build environment.
 
-Next, copy `private-build-plans.toml` to the root of the Iosevka clone. Run
-
 ```bash
+git clone https://github.com/be5invis/Iosevka.git --depth 1
+git clone https://github.com/nanxstats/anthrosevka.git
+
+cd anthrosevka/
+
+IOSEVKA_DIR=/path/to/Iosevka
+
+./patches/apply-patches.sh "$IOSEVKA_DIR"
+cp private-build-plans.toml "$IOSEVKA_DIR/private-build-plans.toml"
+
+cd "$IOSEVKA_DIR"
+npm install
 npm run build -- ttf-unhinted::AnthrosevkaMono
 ```
+
+The built fonts will be in `$IOSEVKA_DIR/dist/AnthrosevkaMono/TTF-Unhinted/`.
 
 ## Disclaimer
 

--- a/patches/001-capital-q-straight-tail.patch
+++ b/patches/001-capital-q-straight-tail.patch
@@ -1,0 +1,19 @@
+diff --git a/packages/font-glyphs/src/letter/latin/upper-q.ptl b/packages/font-glyphs/src/letter/latin/upper-q.ptl
+index 114ea5a..4abae48 100644
+--- a/packages/font-glyphs/src/letter/latin/upper-q.ptl
++++ b/packages/font-glyphs/src/letter/latin/upper-q.ptl
+@@ -82,10 +82,12 @@ glyph-block Letter-Latin-Upper-Q : begin
+ 	# Tails
+ 	define [QStraightTail df] : begin
+ 		local shift : StrokeWidthBlend 0 0.25
++		local rootX : df.middle - [HSwToV Stroke] * shift
++		local endX : [mix df.middle df.rightSB (2 / 3)] - [HSwToV Stroke] * shift
+ 		return : dispiro
+ 			widths.rhs
+-			flat (df.middle - [HSwToV Stroke] * shift - TailDepth * 0.25) TailDepth [heading Upward]
+-			curl (df.middle - [HSwToV Stroke] * shift) 0
++			flat endX TailDepth [widths.rhs.heading (Stroke * 1.08) Upward]
++			curl rootX 0 [widths.rhs Stroke]
+ 
+ 	define [QCurlyTail df] : begin
+ 		local shift : StrokeWidthBlend 0.5 0.6

--- a/patches/002-capital-j-raised-tail.patch
+++ b/patches/002-capital-j-raised-tail.patch
@@ -1,0 +1,20 @@
+diff --git a/packages/font-glyphs/src/letter/latin/upper-j.ptl b/packages/font-glyphs/src/letter/latin/upper-j.ptl
+index 8bc0ec2..2c335fa 100644
+--- a/packages/font-glyphs/src/letter/latin/upper-j.ptl
++++ b/packages/font-glyphs/src/letter/latin/upper-j.ptl
+@@ -25,6 +25,7 @@ glyph-block Letter-Latin-Upper-J : begin
+ 
+ 		local sw : Math.min Stroke : 0.4 * (xBarRight - df.leftSB)
+ 		local hookx : 0.75 * df.leftSB
++		local tailRise : mix 0 top 0.21
+ 
+ 		include : dispiro
+ 			widths.rhs sw
+@@ -32,6 +33,7 @@ glyph-block Letter-Latin-Upper-J : begin
+ 			curl xBarRight ArchDepthB
+ 			HookEnd 0 (sw -- sw)
+ 			g4 hookx Hook
++			straight.up.end hookx (tailRise + Hook) [widths.rhs.heading sw Upward]
+ 
+ 	define [JFlatHookBase df dfHook top] : glyph-proc
+ 		set-width df.width

--- a/patches/003-dotted-zero-rectangular-dot.patch
+++ b/patches/003-dotted-zero-rectangular-dot.patch
@@ -1,0 +1,25 @@
+diff --git a/packages/font-glyphs/src/number/0.ptl b/packages/font-glyphs/src/number/0.ptl
+index 7b46d70..ebc45be 100644
+--- a/packages/font-glyphs/src/number/0.ptl
++++ b/packages/font-glyphs/src/number/0.ptl
+@@ -98,15 +98,13 @@ glyph-block Digits-Zero : begin
+ 			MaskBelow (top * (1/2 + 1/16))
+ 
+ 	define [ZeroDotShape top] : begin
+-		local halfDotWidth : Math.max (DotRadius / 8) : Math.min DotRadius (CircleInnerWidth / 4)
+-		return : OShapeOutline.NoOvershoot
+-			top / 2 + DotRadius
+-			top / 2 - DotRadius
++		local halfDotWidth : Math.max (DotRadius / 8) : Math.min (DotRadius * 0.65) (CircleInnerWidth / 4)
++		local halfDotHeight : DotRadius * 1.2
++		return : Rect
++			top / 2 + halfDotHeight
++			top / 2 - halfDotHeight
+ 			Middle - halfDotWidth
+ 			Middle + halfDotWidth
+-			Stroke * halfDotWidth * 2 / Width
+-			ArchDepthAOf halfDotWidth (halfDotWidth * 2)
+-			ArchDepthBOf halfDotWidth (halfDotWidth * 2)
+ 
+ 	define [ZeroLongDotShape top] : begin
+ 		local halfDotWidth : Math.max (DotRadius / 8) : Math.min HalfStroke (CircleInnerWidth / 4)

--- a/patches/apply-patches.sh
+++ b/patches/apply-patches.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+iosevka_dir=${1:-$(pwd)}
+
+if [ ! -f "$iosevka_dir/verdafile.mjs" ] || [ ! -d "$iosevka_dir/packages/font-glyphs/src" ]; then
+	echo "error: run from the Iosevka source root or pass the Iosevka clone path." >&2
+	echo "usage: $0 [IOSEVKA_DIR]" >&2
+	exit 1
+fi
+
+patches='
+001-capital-q-straight-tail.patch
+002-capital-j-raised-tail.patch
+003-dotted-zero-rectangular-dot.patch
+'
+
+for patch_name in $patches; do
+	patch_file="$script_dir/$patch_name"
+	printf 'Applying %s... ' "$patch_name"
+	if git -C "$iosevka_dir" apply --check "$patch_file" >/dev/null 2>&1; then
+		git -C "$iosevka_dir" apply "$patch_file"
+		printf 'done\n'
+	elif git -C "$iosevka_dir" apply --reverse --check "$patch_file" >/dev/null 2>&1; then
+		printf 'already applied\n'
+	else
+		printf 'failed\n' >&2
+		echo "error: $patch_name does not apply cleanly. Check the Iosevka version or rebase the patch." >&2
+		exit 1
+	fi
+done


### PR DESCRIPTION
This PR:

- Adjusts Iosevka's uppercase `J` and `Q` glyph designs to better match the Anthropic Mono direction.
- Changes the dotted zero from a circular dot to a rectangular dot.
- Adds reusable per-glyph patch files plus a shell script for reapplying these changes after future Iosevka source updates.