### PR TITLE
Align digit `1` flag terminal with base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Anthrosevka Mono 0.3.0
+
+### Glyph design
+
+- Reworked the `1` base variant flag so its terminal aligns with the bottom
+  base and uses a straight vertical end similar to Anthropic Mono.
+
 ## Anthrosevka Mono 0.2.0
 
 ### Glyph design

--- a/patches/004-number-one-vertical-flag.patch
+++ b/patches/004-number-one-vertical-flag.patch
@@ -1,0 +1,24 @@
+diff --git a/packages/font-glyphs/src/number/1.ptl b/packages/font-glyphs/src/number/1.ptl
+index a857268..f69e8cb 100644
+--- a/packages/font-glyphs/src/number/1.ptl
++++ b/packages/font-glyphs/src/number/1.ptl
+@@ -15,10 +15,16 @@ glyph-block Digits-One : begin
+ 
+ 		export : define [Serifed top balance pTopSerif] : glyph-proc
+ 			define topSW : AdviceStroke 3.5
++			local flagDepth : topSW + Stroke / 3
++			local xStemLeft : Middle - [HSwToV HalfStroke] + balance
++			local xTerminal : Middle - LongJut + TanSlope * (Stroke * DesignParameters.serifShiftX)
++			local yTerminalTop : top - Stroke / 8 - Hook * pTopSerif * (top / CAP)
+ 			include : VBar.m (Middle + balance) 0 top
+-			include : dispiro
+-				flat (Middle - [HSwToV HalfStroke] + balance) top [widths.lhs topSW]
+-				curl (Middle - [HSwToV : Stroke / 8] - HookX * 1.25 + balance) (top - Stroke / 8 - Hook * pTopSerif * (top / CAP))
++			include : spiro-outline
++				corner xStemLeft top
++				corner xTerminal yTerminalTop
++				corner xTerminal (yTerminalTop - flagDepth)
++				corner xStemLeft (top - flagDepth)
+ 
+ 		export : define [FlatSerifed top balance pTopSerif] : glyph-proc
+ 			define topSW : AdviceStroke 3.5

--- a/patches/apply-patches.sh
+++ b/patches/apply-patches.sh
@@ -14,6 +14,7 @@ patches='
 001-capital-q-straight-tail.patch
 002-capital-j-raised-tail.patch
 003-dotted-zero-rectangular-dot.patch
+004-number-one-vertical-flag.patch
 '
 
 for patch_name in $patches; do


### PR DESCRIPTION
This PR finetuned the `1` glyph:

- Replaced the previous stroked top flag with an explicit outline.
- Aligned the flag terminal with the left edge of the bottom base stroke.
- Changed the flag end from a diagonal cut to a straight vertical terminal.
- Added `patches/004-number-one-vertical-flag.patch` and registered it in `patches/apply-patches.sh`.